### PR TITLE
Update Dockerfile for Mattermost 3.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 3.6.0
-ENV MATTERMOST_VERSION_SHORT 360
+ENV MATTERMOST_VERSION 3.6.1
+ENV MATTERMOST_VERSION_SHORT 361
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 3.6.1
-ENV MATTERMOST_VERSION_SHORT 361
+ENV MATTERMOST_VERSION 3.6.2
+ENV MATTERMOST_VERSION_SHORT 362
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \


### PR DESCRIPTION
Hey @goern!

Here's a PR to update the project to Mattermost 3.6.1 - [changelog is here](https://docs.mattermost.com/administration/changelog.html#release-v3-6-1).

Thanks again, as always!