### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 4.3.0
-ENV MATTERMOST_VERSION_SHORT 430
+ENV MATTERMOST_VERSION 4.3.1
+ENV MATTERMOST_VERSION_SHORT 431
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \


### PR DESCRIPTION
Hi Goern,

Mattermost v4.3.1 dot release is officially out.  

You can [find download links with hash numbers here](https://pre-release.mattermost.com/core/pl/1m4s4q1q97fezgzuuod4ag8tah).  Changelog with notes on patch releases will be available [here](https://docs.mattermost.com/administration/changelog.html#mattermost-changelog) later today.