### PR TITLE
Propose updating to Mattermost v4.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 4.4.2
-ENV MATTERMOST_VERSION_SHORT 442
+ENV MATTERMOST_VERSION 4.4.5
+ENV MATTERMOST_VERSION_SHORT 445
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \


### PR DESCRIPTION
Hi @goern,

Mattermost v4.4.5 release is officially out.  The release contains a medium severity security fix. Upgrading is highly recommended although you might wish to wait and upgrade when v4.5 is released on Friday, 15 December.

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/buhd5ew387b1mm6bq4p8htm4wa).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-4-5).