### PR TITLE
Propose updating to Mattermost v4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 4.4.5
-ENV MATTERMOST_VERSION_SHORT 445
+ENV MATTERMOST_VERSION 4.5.0
+ENV MATTERMOST_VERSION_SHORT 450
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \


### PR DESCRIPTION
Hey @goern, Mattermost v4.5 release is officially out!

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/9buqjpu6eidyxbd75xbjdn19zc).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html?highlight=changelog#release-v4-5).

Wondering if you'd like to help update Mattermost Openshift to be compatible with Mattermost 4.5?

If you do update, please consider tweeting about it, which we can then re-tweet for greater reach.

Thanks!