### PR TITLE
Propose upgrading to Mattermost v4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 4.5.0
-ENV MATTERMOST_VERSION_SHORT 450
+ENV MATTERMOST_VERSION 4.7.0
+ENV MATTERMOST_VERSION_SHORT 470
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \


### PR DESCRIPTION
Hi @goern,

Mattermost v4.7 release is officially out!

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/ezdkj88no7yd3qn4h5z3i8cbqr).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html#release-v4-7).