### PR TITLE
Propose Upgrading to Mattermost 4.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ MAINTAINER Christoph Görn <goern@b4mad.net>
 # based on the work of Takayoshi Kimura <tkimura@redhat.com>
 
 ENV container docker
-ENV MATTERMOST_VERSION 4.7.0
-ENV MATTERMOST_VERSION_SHORT 470
+ENV MATTERMOST_VERSION 4.7.2
+ENV MATTERMOST_VERSION_SHORT 472
 
 # Labels consumed by Red Hat build service
 LABEL Component="mattermost" \


### PR DESCRIPTION
Hi @goern,

Mattermost v4.7.2 release was cut yesterday...

You can find download links with hash numbers [here](https://pre-release.mattermost.com/core/pl/3qtanuti1jgbuympmhmu6g1sce).  Changelog with notes on patch releases is available [here](https://docs.mattermost.com/administration/changelog.html#release-v4-7).

Thanks for helping to keep mattermost-openshift updated!